### PR TITLE
Adjust simulation parameters for diffusion flame

### DIFF
--- a/Tabulation/data_gene_init.py
+++ b/Tabulation/data_gene_init.py
@@ -81,11 +81,7 @@ if step == 0:
         f.oxidizer_inlet.T = parameter_dict['oxidizer_temperature']
         f.fuel_inlet.mdot = fuel_inlet_mdot
         f.oxidizer_inlet.mdot = oxidizer_inlet_mdot
-        solver = f.get_steady_solver()
-        solver.time_control.max_time_steps = 2000  # Set the maximum time steps
-        solver.time_control.max_dt = 10.0          # Optional: Set max time step
-        solver.time_control.dt_max_factor = 20.0   # Optional: Set max step growth
-        #f.time_control.max_time_steps = 2000
+        f.set_time_step(1e-5, [2000])
         f.set_refine_criteria(ratio=2, slope=0.05, curve=0.1, prune=0.0)
         f.set_max_points(2000)
         f.solve(loglevel=1, auto=True)
@@ -100,11 +96,7 @@ if step == 0:
         f.oxidizer_inlet.T = parameter_dict['oxidizer_temperature']
         f.fuel_inlet.mdot = fuel_inlet_mdot
         f.oxidizer_inlet.mdot = oxidizer_inlet_mdot
-        solver = f.get_steady_solver()
-        solver.time_control.max_time_steps = 2000  # Set the maximum time steps
-        solver.time_control.max_dt = 10.0          # Optional: Set max time step
-        solver.time_control.dt_max_factor = 20.0   # Optional: Set max step growth
-        #f.time_control.max_time_steps = 2000
+        f.set_time_step(1e-5, [2000])
         f.set_refine_criteria(ratio=2, slope=0.05, curve=0.1, prune=0.0)
         f.set_max_points(2000)
         f.solve(loglevel=1, auto=True)
@@ -137,11 +129,7 @@ else:
     f.oxidizer_inlet.T = parameter_dict['oxidizer_temperature']
     f.fuel_inlet.mdot = fuel_inlet_mdot
     f.oxidizer_inlet.mdot = oxidizer_inlet_mdot
-    solver = f.get_steady_solver()
-    solver.time_control.max_time_steps = 2000  # Set the maximum time steps
-    solver.time_control.max_dt = 10.0          # Optional: Set max time step
-    solver.time_control.dt_max_factor = 20.0   # Optional: Set max step growth
-    #f.time_control.max_time_steps = 2000
+    f.set_time_step(1e-5, [2000])
     f.set_max_points(2000)
     f.set_refine_criteria(ratio=2, slope=0.05, curve=0.1, prune=0.0)
     


### PR DESCRIPTION
Replace deprecated Cantera 3.2 flame solver time control to resolve `AttributeError`.

The `get_steady_solver()` and `time_control` attributes are deprecated in Cantera 3.2.0a2. This PR updates the code to use `f.set_time_step()` directly on the `CounterflowDiffusionFlame` object, allowing control over time steps and mesh refinement without triggering `AttributeError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-20104aa8-2c35-4954-85c1-2c492b6bbe87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-20104aa8-2c35-4954-85c1-2c492b6bbe87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

